### PR TITLE
Added segment event tracking for all sign up links

### DIFF
--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -13,7 +13,12 @@ import emailNav from "../images/email-nav.svg";
 
 import mobileMenu from "../images/hamburger.svg";
 
-import { githubSignUpUrl, googleSignUpUrl, emailSignUpUrl } from "../links";
+import {
+  githubSignUpUrl,
+  googleSignUpUrl,
+  emailSignUpUrl,
+  trackSignUp,
+} from "../links";
 
 const NavContainer = styled.section`
   position: fixed;
@@ -155,17 +160,32 @@ const NavigationComponent: React.FC = () => {
               <AccountButtons>
                 <label>Sign Up</label>
                 <li>
-                  <a href={googleSignUpUrl} rel="noreferrer" target="_blank">
+                  <a
+                    href={googleSignUpUrl}
+                    rel="noreferrer"
+                    target="_blank"
+                    onClick={() => trackSignUp("Google")}
+                  >
                     <img src={googleNav} alt="Google SSO" />
                   </a>
                 </li>
                 <li>
-                  <a href={githubSignUpUrl} rel="noreferrer" target="_blank">
+                  <a
+                    href={githubSignUpUrl}
+                    rel="noreferrer"
+                    target="_blank"
+                    onClick={() => trackSignUp("GitHub")}
+                  >
                     <img src={githubNav} alt="GitHub SSO" />
                   </a>
                 </li>
                 <li>
-                  <a href={emailSignUpUrl} rel="noreferrer" target="_blank">
+                  <a
+                    href={emailSignUpUrl}
+                    rel="noreferrer"
+                    target="_blank"
+                    onClick={() => trackSignUp("Email")}
+                  >
                     <img src={emailNav} alt="Sign Up with Email" />
                   </a>
                 </li>
@@ -173,7 +193,7 @@ const NavigationComponent: React.FC = () => {
               <MobileButtons>
                 <li className="hamburger">
                   <a href="/" onClick={toggleMenu}>
-                    <img src={mobileMenu} alt="+"/>
+                    <img src={mobileMenu} alt="+" />
                   </a>
                 </li>
               </MobileButtons>
@@ -198,17 +218,29 @@ const NavigationComponent: React.FC = () => {
             <Link to="/#company">Company</Link>
           </li> */}
           <li>
-            <a href="https://docs.trycourier.com/" rel="noreferrer" target="_blank">
+            <a
+              href="https://docs.trycourier.com/"
+              rel="noreferrer"
+              target="_blank"
+            >
               Documentation
             </a>
           </li>
           <li>
-            <a href="https://www.trycourier.app/login" rel="noreferrer" target="_blank">
+            <a
+              href="https://www.trycourier.app/login"
+              rel="noreferrer"
+              target="_blank"
+            >
               Login
             </a>
           </li>
           <li>
-            <a href="https://www.trycourier.app/register" rel="noreferrer" target="_blank">
+            <a
+              href="https://www.trycourier.app/register"
+              rel="noreferrer"
+              target="_blank"
+            >
               Sign Up
             </a>
           </li>

--- a/src/components/pricing/feature-table.tsx
+++ b/src/components/pricing/feature-table.tsx
@@ -121,6 +121,7 @@ import {
   googleSignUpUrl,
   emailSignUpUrl,
   signUpUrl,
+  trackSignUp,
 } from "../../links";
 
 const AccountButtons = styled.ul`
@@ -189,17 +190,29 @@ const AccountButtonComponent: React.FC = () => {
   return (
     <AccountButtons>
       <li className="google">
-        <a href={googleSignUpUrl} target="_blank">
+        <a
+          href={googleSignUpUrl}
+          target="_blank"
+          onClick={() => trackSignUp("Google")}
+        >
           <img src={googleLogo} alt="Google SSO" />
         </a>
       </li>
       <li className="github">
-        <a href={githubSignUpUrl} target="_blank">
+        <a
+          href={githubSignUpUrl}
+          target="_blank"
+          onClick={() => trackSignUp("GitHub")}
+        >
           <img src={githubLogo} alt="GitHub SSO" />
         </a>
       </li>
       <li className="email">
-        <a href={emailSignUpUrl} target="_blank">
+        <a
+          href={emailSignUpUrl}
+          target="_blank"
+          onClick={() => trackSignUp("Email")}
+        >
           <img src={emailLogo} alt="Sign Up with Email" />
         </a>
       </li>
@@ -264,6 +277,7 @@ const handleContactSalesClick = () => {
 
 const handleSignUpClick = () => {
   try {
+    trackSignUp();
     window.open(signUpUrl, "_blank");
   } catch (e) {
     console.warn("Window not available.");

--- a/src/components/shared/registration-cta.tsx
+++ b/src/components/shared/registration-cta.tsx
@@ -8,7 +8,13 @@ import emailLogo from "../../images/email-logo-white.svg";
 import colors from "../../colors";
 import { Desktop, Mobile } from "../container";
 
-import { githubSignUpUrl, googleSignUpUrl, emailSignUpUrl, signUpUrl } from "../../links";
+import {
+  githubSignUpUrl,
+  googleSignUpUrl,
+  emailSignUpUrl,
+  signUpUrl,
+  trackSignUp,
+} from "../../links";
 
 const Button = styled.button`
   ${tw`rounded-full mr-2 px-4 py-2 text-white text-sm align-middle`}
@@ -90,32 +96,32 @@ const Flex = styled.div`
 
 const handleSignUpClick = () => {
   try {
+    trackSignUp();
     window.open(signUpUrl, "_blank");
   } catch (e) {
     console.warn("Window not available.");
   }
 };
 
-
-const RegistrationCTA: React.FC = (props) => {
+const RegistrationCTA: React.FC = props => {
   return (
     <Content footer={props.footer}>
       <div className="form">
         <Desktop>
           <Flex>
-            <a href={googleSignUpUrl}>
+            <a href={googleSignUpUrl} onClick={() => trackSignUp("Google")}>
               <Button>
                 <img src={googleLogo} alt="Google SSO" />
                 <label>Google</label>
               </Button>
             </a>
-            <a href={githubSignUpUrl}>
+            <a href={githubSignUpUrl} onClick={() => trackSignUp("GitHub")}>
               <Button className="github">
                 <img src={githubLogo} alt="GitHub SSO" />
                 <label>GitHub</label>
               </Button>
             </a>
-            <a href={emailSignUpUrl}>
+            <a href={emailSignUpUrl} onClick={() => trackSignUp("Email")}>
               <button className="ghost">
                 or <strong>email</strong>
               </button>
@@ -124,16 +130,16 @@ const RegistrationCTA: React.FC = (props) => {
         </Desktop>
         <Mobile>
           <MobileRegistrationCTA>
-              <Button className="mobile" onClick={handleSignUpClick}>
-                <label>Sign up!</label>
-                <div>
-                    <img src={googleLogo} alt="Google SSO" />
-                    <img src={githubLogo} alt="GitHub SSO" />
-                    <img className="email" src={emailLogo} alt="Email" />
-                </div>
-              </Button>
-            </MobileRegistrationCTA>
-          </Mobile>
+            <Button className="mobile" onClick={handleSignUpClick}>
+              <label>Sign up!</label>
+              <div>
+                <img src={googleLogo} alt="Google SSO" />
+                <img src={githubLogo} alt="GitHub SSO" />
+                <img className="email" src={emailLogo} alt="Email" />
+              </div>
+            </Button>
+          </MobileRegistrationCTA>
+        </Mobile>
       </div>
     </Content>
   );

--- a/src/links.ts
+++ b/src/links.ts
@@ -4,3 +4,9 @@ export const googleSignUpUrl =
   "https://courier.auth.us-east-1.amazoncognito.com/oauth2/authorize?identity_provider=Google&redirect_uri=https://www.trycourier.app/login/callback&response_type=CODE&client_id=5f4fmec2qnuscp89qbt8nsuftj&scope=aws.cognito.signin.user.admin%20email%20openid%20profile";
 export const emailSignUpUrl = "https://www.trycourier.app/register/email";
 export const signUpUrl = "https://www.trycourier.app/register/";
+
+type SignUpType = "GitHub" | "Google" | "Email";
+
+export const trackSignUp = (type?: SignUpType): void => {
+  window.analytics.track("Sign Up", { category: "Account", label: type });
+};


### PR DESCRIPTION
## Description of the change

Added Segment Event Tracking for all Sign Up links. This should flow through to Google Analytics.

For Mobile clicks, we won't be able to differentiate between sign up types. The label property is optional. We'll just see it as a sign up action from a mobile device. 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
