### PR TITLE
Converted internal links to use Gatsby Link Component

### DIFF
--- a/src/components/community/articles.tsx
+++ b/src/components/community/articles.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from "react";
+import { Link } from "gatsby";
 import styled, { css } from "styled-components";
 import tw from "tailwind.macro";
 import Avatar from "../../images/avatar@2x.png";
@@ -17,7 +18,7 @@ export const ArticleSearch = styled.div`
   ${tw`w-full md:w-1/4 mt-8`}
 `;
 
-export const ArticleHeaderLink = styled.a`
+export const ArticleHeaderLink = styled(Link)`
   ${tw`no-underline`}
   & :hover {
     text-decoration: underline;
@@ -92,7 +93,7 @@ export const ArticlePosted: React.FC<ArticlePostedType> = ({ id, name, date }) =
   <PostedContent>
     Posted by{" "}
     <strong>
-      <a href={`/blog/authors/${id}`}>{name}</a>
+      <Link to={`/blog/authors/${id}`}>{name}</Link>
     </strong>{" "}
     on <strong>{date}</strong>
   </PostedContent>
@@ -122,9 +123,9 @@ export const AuthorCard: React.FC<ArticleAuthorType> = ({id, name, avatar}) => (
       Author
       <br />
       <strong>
-        <a href={`/blog/authors/${id}`}>
+        <Link to={`/blog/authors/${id}`}>
           {name}
-        </a>
+        </Link>
       </strong>
     </p>
   </AuthorCardContent>

--- a/src/components/community/back-link.tsx
+++ b/src/components/community/back-link.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "gatsby";
 import styled from "styled-components";
 import tw from "tailwind.macro";
 import IconBack from "../../images/icon-back.svg";
@@ -10,7 +11,7 @@ const BackImg = styled.img`
   transition-duration: 300ms;
 `;
 
-const BackLink = styled.a`
+const BackLink = styled(Link)`
   ${tw`relative no-underline items-center justify-between py-2 px-6`}
   background: ${colors.berryGlass};
   color: ${colors.berry};
@@ -26,7 +27,7 @@ const BackLink = styled.a`
 const BackLinkComponent: React.FC = () => {
   return (
     <div style={{height: 48}}>
-      <BackLink href="/blog">
+      <BackLink to="/blog">
         <BackImg src={IconBack} alt="Back" /> View all Articles
       </BackLink>
     </div>

--- a/src/components/community/tag.tsx
+++ b/src/components/community/tag.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Link } from "gatsby";
 import styled from "styled-components";
 
 const Tag = styled.div`
@@ -19,9 +20,9 @@ type TagType = {
 const TagComponent: React.FC<TagType> = ({ label }) => {
   const tagRoute = label.toLowerCase().replace(/ /gi, "-");
   return (
-    <a href={`/blog/tags/${tagRoute}`}>
+    <Link to={`/blog/tags/${tagRoute}`}>
       <Tag>{label}</Tag>
-    </a>
+    </Link>
   );
 };
 

--- a/src/components/footer.tsx
+++ b/src/components/footer.tsx
@@ -133,10 +133,10 @@ const FooterComponent: React.FC = () => {
           </SocialLinks>
           <DetailLinks>
             <p>
-              <a href="/terms">Terms&nbsp;of&nbsp;Service</a>
-              <a href="/privacy">Privacy&nbsp;Policy</a>
-              <a href="/disclosure">Responsible&nbsp;Disclosure&nbsp;Policy</a>
-              <a href="/subprocessors">Data Subprocessors</a>
+              <Link to="/terms">Terms&nbsp;of&nbsp;Service</Link>
+              <Link to="/privacy">Privacy&nbsp;Policy</Link>
+              <Link to="/disclosure">Responsible&nbsp;Disclosure&nbsp;Policy</Link>
+              <Link to="/subprocessors">Data Subprocessors</Link>
               <a href="https://jobs.lever.co/trycourier" rel="noreferrer" target="_blank">Careers</a>
             </p>
           </DetailLinks>

--- a/src/pages/blog/authors.tsx
+++ b/src/pages/blog/authors.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { graphql } from "gatsby";
+import { graphql, Link } from "gatsby";
 
 import Simple from "../../templates/simple";
 
@@ -35,9 +35,9 @@ const Authors: React.FC = ({ data }: any) => {
         <ArticleList>
           {authors.map(({node}) => (
             <ArticleCard key={node.id}>
-              <a href={`/blog/authors/${node.slug}`}>
+              <Link to={`/blog/authors/${node.slug}`}>
                 {node.name}
-              </a>
+              </Link>
             </ArticleCard>
           ))}
         </ArticleList>

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { graphql } from "gatsby";
+import { graphql, Link } from "gatsby";
 
 import Simple from "../../templates/simple";
 
@@ -81,14 +81,14 @@ const Blog: React.FC = ({ data }: any) => {
             })
             .map(({ node }: any) => (
               <ArticleCard key={node.id}>
-                <a href={`/blog/${node.slug}`}>
+                <Link to={`/blog/${node.slug}`}>
                   <ArticleImage
                     src={node.thumbnail.file.url}
                     alt={node.title}
                   />
-                </a>
+                </Link>
                 <ArticlePreview>
-                  <ArticleHeaderLink href={`/blog/${node.slug}`}>
+                  <ArticleHeaderLink to={`/blog/${node.slug}`}>
                     <h4>{node.title}</h4>
                   </ArticleHeaderLink>
                   <ArticlePosted

--- a/src/pages/blog/tags.tsx
+++ b/src/pages/blog/tags.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { graphql } from "gatsby";
+import { graphql, Link } from "gatsby";
 
 import Simple from "../../templates/simple";
 
@@ -33,9 +33,9 @@ const Blog: React.FC = ({ data }: any) => {
         <ArticleList>
           {tags.map(({ fieldValue, totalCount }) => (
             <ArticleCard key={fieldValue}>
-              <a href={fieldValue}>
+              <Link to={fieldValue}>
                 <Tag label={fieldValue}> ( {totalCount} ) </Tag>
-              </a>
+              </Link>
             </ArticleCard>
           ))}
         </ArticleList>

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { graphql } from "gatsby";
+import { graphql, Link } from "gatsby";
 
 import Simple from "../templates/simple";
 
@@ -19,44 +19,6 @@ import SearchInput from "../components/community/search-input";
 import Tag from "../components/community/tag";
 
 import colors from "../colors";
-
-const tags = ["Example"]
-
-/*export const query = graphql`
-  query {
-    allMarkdownRemark(
-      limit: 5,
-      sort: { fields: [frontmatter___date], order: DESC }
-      filter: {
-        frontmatter: {hidden: {eq: "false"}}
-      }
-    ) {
-      totalCount
-      edges {
-        node {
-          id
-          frontmatter {
-            hidden
-            title
-            date(formatString: "MMMM Do, YYYY")
-            thumbnail
-            tags
-            author {
-              id
-              bio
-              name
-              twitter
-            }
-          }
-          fields {
-            slug
-          }
-          excerpt
-        }
-      }
-    }
-  }
-`;*/
 
 export const query = graphql`
   query {
@@ -125,17 +87,17 @@ const Community: React.FC = ({ data }: any) => {
           {articles.filter(({ node }) => {
               return searchContent(node.title);
             })
-          .map(({ node }: any, idx: Number) => (
-            <ArticleCard key={node.id} key={idx}>
-              <a href={node.slug}>
+          .map(({ node }: any) => (
+            <ArticleCard key={node.id}>
+              <Link to={`/blog/${node.slug}`}>
                 <ArticleImage
                   src={node.thumbnail.file.url}
                   alt={node.title}
                 />
-              </a>
+              </Link>
 
               <ArticlePreview>
-                <ArticleHeaderLink href={`/blog/${node.slug}`}>
+                <ArticleHeaderLink to={`/blog/${node.slug}`}>
                   <h4>{node.title}</h4>
                 </ArticleHeaderLink>
                 <ArticlePosted
@@ -145,7 +107,7 @@ const Community: React.FC = ({ data }: any) => {
                 />
                 <p className="excerpt">{node.excerpt.excerpt}</p>
                 <div>
-                  {node.tags.map((tag: string, idx: number) => (
+                  {node.tags.map((tag: {name: string}, idx: number) => (
                     <span style={{ marginRight: 8 }} key={idx}>
                       <Tag label={tag.name} />
                     </span>

--- a/src/templates/author.tsx
+++ b/src/templates/author.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { graphql } from "gatsby";
+import { graphql, Link } from "gatsby";
 import styled from "styled-components";
 import tw from "tailwind.macro";
 import Simple from "./simple";
@@ -19,7 +19,7 @@ import Tag from "../components/community/tag";
 
 import colors from "../colors";
 
-const HeaderLink = styled.a`
+const HeaderLink = styled(Link)`
   ${tw`no-underline`}
   & :hover {
     text-decoration: underline;
@@ -113,15 +113,15 @@ const Authored: React.FC<AuthoredTypes> = ({ pageContext, data }) => {
           <ArticleList>
             {posts.map(({ node }: any) => (
               <ArticleCard key={node.id}>
-                <a href={`/blog/${node.slug}`}>
+                <Link to={`/blog/${node.slug}`}>
                   <ArticleImage
                     src={node.thumbnail.file.url}
                     alt={node.title}
                   />
-                </a>
+                </Link>
 
                 <div className="px-4">
-                  <HeaderLink href={`/blog/${node.slug}`}>
+                  <HeaderLink to={`/blog/${node.slug}`}>
                     <h4 className="font-bold text-xl py-0 mt-0 mb-2">
                       {node.title}
                     </h4>

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -99,7 +99,6 @@ const BlogPost: React.FC<GraphQLQuery> = ({ data }) => {
   const options = {
     renderNode: {
       [INLINES.HYPERLINK]: (node) => {
-        console.log(node);
         if((node.data.uri).includes("player.vimeo.com/video")){
           return <IframeContainer><iframe title={node.content[0].value} src={node.data.uri} frameBorder="0" allowFullScreen></iframe></IframeContainer>
         } else if((node.data.uri).includes("youtube.com/embed")) {

--- a/src/templates/tag.tsx
+++ b/src/templates/tag.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { graphql } from "gatsby";
+import { graphql, Link } from "gatsby";
 import styled from "styled-components";
 import tw from "tailwind.macro";
 import Simple from "./simple";
@@ -16,7 +16,7 @@ import BackLink from "../components/community/back-link";
 import SearchInput from "../components/community/search-input";
 import Tag from "../components/community/tag";
 
-const HeaderLink = styled.a`
+const HeaderLink = styled(Link)`
   ${tw`no-underline`}
   & :hover {
     text-decoration: underline;
@@ -47,10 +47,10 @@ const TaggedFooter = styled.div`
 `;
 
 export const query = graphql`
-  query($tagId: [String]) {
+  query($tagId: String!) {
     allContentfulPost(
       limit: 1000
-      filter: { tags: {elemMatch: {id: {in: $tagId}}}}
+      filter: { tags: {elemMatch: {id: {eq: $tagId}}}}
     ) {
       totalCount
       group(field: tags___name) {
@@ -94,7 +94,6 @@ type TaggedTypes = {
 const Tagged: React.FC<TaggedTypes> = ({ pageContext, data }) => {
   const { tag } = pageContext;
   const posts = data.allContentfulPost.edges;
-
   const tags = data.allContentfulPost.group;
 
   return (
@@ -112,15 +111,15 @@ const Tagged: React.FC<TaggedTypes> = ({ pageContext, data }) => {
           <ArticleList>
             {posts.map(({ node }: any) => (
               <ArticleCard key={node.id}>
-                <a href={`/blog/${node.slug}`}>
+                <Link to={`/blog/${node.slug}`}>
                   <ArticleImage
                     src={node.thumbnail.file.url}
                     alt={node.title}
                   />
-                </a>
+                </Link>
 
                 <div className="px-4">
-                  <HeaderLink href={`/blog/${node.slug}`}>
+                  <HeaderLink to={`/blog/${node.slug}`}>
                     <h4 className="font-bold text-xl py-0 mt-0 mb-2">
                       {node.title}
                     </h4>


### PR DESCRIPTION
## Description of the change

Converted internal links using anchor tags to using the Gatsby Link component. This provides a smoother page transition.
Also a bit of cleanup and fixed the tag page template query.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
