### PR TITLE
Fix tag and author pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -22,7 +22,6 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       allContentfulAuthor {
         edges {
           node {
-            name
             slug
           }
         }
@@ -30,8 +29,6 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       allContentfulTag {
         edges {
           node {
-            id
-            name
             slug
           }
         }
@@ -63,8 +60,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       path: `blog/authors/${node.slug}`,
       component: path.resolve(`./src/templates/author.tsx`),
       context: {
-        author: node,
-        authorId: node.slug
+        slug: node.slug
       },
     })
   })
@@ -75,7 +71,6 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
       path: `blog/tags/${node.slug}`,
       component: path.resolve(`./src/templates/tag.tsx`),
       context: {
-        tag: node,
         slug: node.slug
       }
     })

--- a/src/templates/author.tsx
+++ b/src/templates/author.tsx
@@ -50,42 +50,38 @@ const AuthoredFooter = styled.div`
 `;
 
 export const query = graphql`
-  query ($authorId: [String]){
+  query ($slug: String!) {
     groupedTags: allContentfulPost {
       group(field: tags___name) {
         fieldValue
         totalCount
       }
     }
-    allContentfulPost(
-      limit: 1000
-      filter: { authors: {elemMatch: {slug: {in: $authorId}}}}
-    ) {
-      totalCount
-      edges {
-        node {
+    contentfulAuthor(slug: {eq: $slug}) {
+      name
+      slug
+      post {
+        id
+        title
+        slug
+        tags {
           id
-          title
-          tags {
-            id
-            name
-            slug
-          }
-          createdAt(formatString: "MMMM Do, YYYY")
-          publishDate(formatString: "MMMM Do, YYYY")
-          thumbnail {
-            fluid(maxWidth: 220) {
-              src
-            }
-          }
-          authors {
-            slug
-            name
-          }
+          name
           slug
-          excerpt {
-            excerpt
+        }
+        createdAt(formatString: "MMMM Do, YYYY")
+        publishDate(formatString: "MMMM Do, YYYY")
+        thumbnail {
+          fluid(maxWidth: 220) {
+            src
           }
+        }
+        authors {
+          slug
+          name
+        }
+        excerpt {
+          excerpt
         }
       }
     }
@@ -97,9 +93,9 @@ type AuthoredTypes = {
   data: any;
 };
 
-const Authored: React.FC<AuthoredTypes> = ({ pageContext, data }) => {
-  const { author } = pageContext;
-  const posts = data.allContentfulPost.edges;
+const Authored: React.FC<AuthoredTypes> = ({ data }) => {
+  const author = data.contentfulAuthor;
+  const posts = author.post;
   const tags = data.groupedTags.group;
 
   return (
@@ -115,29 +111,29 @@ const Authored: React.FC<AuthoredTypes> = ({ pageContext, data }) => {
         </AuthoredHeader>
         <ArticleScreen>
           <ArticleList>
-            {posts.map(({ node }: any) => (
-              <ArticleCard key={node.id}>
-                <Link to={`/blog/${node.slug}`}>
+            {posts.map((post: any) => (
+              <ArticleCard key={post.id}>
+                <Link to={`/blog/${post.slug}`}>
                   <ArticleImage
-                    src={node.thumbnail.fluid.src}
-                    alt={node.title}
+                    src={post.thumbnail.fluid.src}
+                    alt={post.title}
                   />
                 </Link>
 
                 <div className="px-4">
-                  <HeaderLink to={`/blog/${node.slug}`}>
+                  <HeaderLink to={`/blog/${post.slug}`}>
                     <h4 className="font-bold text-xl py-0 mt-0 mb-2">
-                      {node.title}
+                      {post.title}
                     </h4>
                   </HeaderLink>
                   <ArticlePosted
-                    id={node.authors[0].slug}
-                    name={node.authors[0].name}
-                    date={node.publishDate || node.createdAt}
+                    id={post.authors[0].slug}
+                    name={post.authors[0].name}
+                    date={post.publishDate || post.createdAt}
                   />
-                  <p className="excerpt">{node.excerpt.excerpt}</p>
+                  <p className="excerpt">{post.excerpt.excerpt}</p>
                   <div>
-                    {node.tags.map((tag: {name: string, id: string, slug: string}) => (
+                    {post.tags.map((tag: {name: string, id: string, slug: string}) => (
                       <span style={{ marginRight: 8 }} key={tag.id}>
                         <Tag label={tag.name} slug={tag.slug} />
                       </span>

--- a/src/templates/author.tsx
+++ b/src/templates/author.tsx
@@ -95,7 +95,7 @@ type AuthoredTypes = {
 
 const Authored: React.FC<AuthoredTypes> = ({ data }) => {
   const author = data.contentfulAuthor;
-  const posts = author.post;
+  const posts = author.post || [];
   const tags = data.groupedTags.group;
 
   return (

--- a/src/templates/blog-post.tsx
+++ b/src/templates/blog-post.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { graphql } from "gatsby";
+import Img from "gatsby-image";
 import { BLOCKS, INLINES, MARKS } from '@contentful/rich-text-types'
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer';
 import styled from "styled-components";
@@ -90,7 +91,7 @@ export const query = graphql`
           url
         }
         fluid(maxWidth: 1000) {
-          src
+          ...GatsbyContentfulFluid
         }
       }
       createdAt(formatString: "MMMM Do, YYYY")
@@ -154,7 +155,7 @@ const BlogPost: React.FC<GraphQLQuery> = ({ data }) => {
       <BackLink />
 
       <BlogContent>
-        <img src={post.headerImage.fluid.src} style={{ borderRadius: 10 }} />
+        <Img fluid={post.headerImage.fluid} style={{ borderRadius: 10 }} />
         <BlogHeader>
           <h1>{post.title}</h1>
           <ArticlePosted

--- a/src/templates/tag.tsx
+++ b/src/templates/tag.tsx
@@ -94,7 +94,7 @@ type TaggedTypes = {
 
 const Tagged: React.FC<TaggedTypes> = ({ data }) => {
   const tag = data.contentfulTag;
-  const posts = tag.post;
+  const posts = tag.post || [];
   const tags = data.groupedTags.group;
 
   return (

--- a/src/templates/tag.tsx
+++ b/src/templates/tag.tsx
@@ -47,43 +47,40 @@ const TaggedFooter = styled.div`
 `;
 
 export const query = graphql`
-  query($slug: [String]) {
+  query($slug: String!) {
     groupedTags: allContentfulPost {
       group(field: tags___name) {
         fieldValue
         totalCount
       }
     }
-    allContentfulPost(
-      limit: 1000
-      filter: { tags: {elemMatch: {slug: {in: $slug}}}}
-    ) {
-      totalCount
-      edges {
-        node {
+    contentfulTag(slug: {eq: $slug}) {
+      id
+      name
+      slug
+      post {
+        id
+        slug
+        title
+        createdAt(formatString: "MMMM Do, YYYY")
+        publishDate(formatString: "MMMM Do, YYYY")
+        tags {
           id
+          name
           slug
-          tags {
-            id
-            name
-            slug
+        }
+        thumbnail {
+          fluid(maxWidth: 220) {
+            src
           }
-          title
-          createdAt(formatString: "MMMM Do, YYYY")
-          publishDate(formatString: "MMMM Do, YYYY")
-          thumbnail {
-            fluid(maxWidth: 220) {
-              src
-            }
-          }
-          authors {
-            id
-            name
-            slug
-          }
-          excerpt {
-            excerpt
-          }
+        }
+        authors {
+          id
+          name
+          slug
+        }
+        excerpt {
+          excerpt
         }
       }
     }
@@ -95,9 +92,9 @@ type TaggedTypes = {
   data: any;
 };
 
-const Tagged: React.FC<TaggedTypes> = ({ pageContext, data }) => {
-  const { tag } = pageContext;
-  const posts = data.allContentfulPost.edges;
+const Tagged: React.FC<TaggedTypes> = ({ data }) => {
+  const tag = data.contentfulTag;
+  const posts = tag.post;
   const tags = data.groupedTags.group;
 
   return (
@@ -113,29 +110,29 @@ const Tagged: React.FC<TaggedTypes> = ({ pageContext, data }) => {
         </TaggedHeader>
         <ArticleScreen>
           <ArticleList>
-            {posts.map(({ node }: any) => (
-              <ArticleCard key={node.id}>
-                <Link to={`/blog/${node.slug}`}>
+            {posts.map((post: any) => (
+              <ArticleCard key={post.id}>
+                <Link to={`/blog/${post.slug}`}>
                   <ArticleImage
-                    src={node.thumbnail.fluid.src}
-                    alt={node.title}
+                    src={post.thumbnail.fluid.src}
+                    alt={post.title}
                   />
                 </Link>
 
                 <div className="px-4">
-                  <HeaderLink to={`/blog/${node.slug}`}>
+                  <HeaderLink to={`/blog/${post.slug}`}>
                     <h4 className="font-bold text-xl py-0 mt-0 mb-2">
-                      {node.title}
+                      {post.title}
                     </h4>
                   </HeaderLink>
                   <ArticlePosted
-                    id={node.authors[0].slug}
-                    name={node.authors[0].name}
-                    date={node.publishDate || node.createdAt}
+                    id={post.authors[0].slug}
+                    name={post.authors[0].name}
+                    date={post.publishDate || post.createdAt}
                   />
-                  <p className="excerpt">{node.excerpt.excerpt}</p>
+                  <p className="excerpt">{post.excerpt.excerpt}</p>
                   <div>
-                    {node.tags.map((tag: {name: string, id: string, slug: string}) => (
+                    {post.tags.map((tag: {name: string, id: string, slug: string}) => (
                       <span style={{ marginRight: 8 }} key={tag.id}>
                         <Tag label={tag.name} slug={tag.slug} />
                       </span>


### PR DESCRIPTION
## Description of the change

Rewrote the queries for tag and author pages. The only queries wouldn't always work. Taking advantage of the 2-way reference Contentful provides. This ends up being cleaner.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
