### PR TITLE
convert register links to app.courier.com

### DIFF
--- a/src/links.ts
+++ b/src/links.ts
@@ -2,8 +2,8 @@ export const githubSignUpUrl =
   "https://courier.auth.us-east-1.amazoncognito.com/oauth2/authorize?identity_provider=Github&redirect_uri=https://trycourier.app/login/callback&response_type=CODE&client_id=5f4fmec2qnuscp89qbt8nsuftj&scope=aws.cognito.signin.user.admin%20email%20openid%20profile";
 export const googleSignUpUrl =
   "https://courier.auth.us-east-1.amazoncognito.com/oauth2/authorize?identity_provider=Google&redirect_uri=https://www.trycourier.app/login/callback&response_type=CODE&client_id=5f4fmec2qnuscp89qbt8nsuftj&scope=aws.cognito.signin.user.admin%20email%20openid%20profile";
-export const emailSignUpUrl = "https://www.trycourier.app/register/email";
-export const signUpUrl = "https://www.trycourier.app/register/";
+export const emailSignUpUrl = "https://app.courier.com/register/email";
+export const signUpUrl = "https://app.courier.com/register/";
 
 type SignUpType = "GitHub" | "Google" | "Email";
 


### PR DESCRIPTION
change registration links to point to `app.courier.com`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
