### PR TITLE
Update Free Tier data retention

### DIFF
--- a/src/data/pricing.tsx
+++ b/src/data/pricing.tsx
@@ -106,7 +106,7 @@ export const features = [
   },
   {
     label: "Log Retention",
-    developer: "48 Hours",
+    developer: "72 Hours",
     pro: "7 Days",
     business: "30 Days",
   },


### PR DESCRIPTION
## Description of the change

Free tier retention should reflect the minimum time required to "retry" the message. This is currently 72 hours (3 days)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Text Change

## Related issues

https://linear.app/trycourier/issue/C-1892/update-free-tier-retention-period