### PR TITLE
Added redirect for hackabull sponsorship

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -17,6 +17,12 @@
   status = 301
   force = true
 
+[[redirects]]
+  from = "https://www.courier.com/hackabull"
+  to = "https://app.courier.com/?utm_medium=hackathon&utm_source=hackbull-usf&utm_campaign=developer-relations"
+  status = 301
+  force = true
+
 # other redirects
 
 [[redirects]]


### PR DESCRIPTION
## Description of the change

Added a redirect to the netlify.toml to send www.courier.com/hackabull to the app with utm codes.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
