### PR TITLE
fix multiple redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -109,7 +109,7 @@
   
 [[redirects]]
   from = "http://trycourier.com/*"
-  to = "https://www.courier.com/:splat"
+  to = "https://www.courier.com/:splat/"
   status = 301
   force = true
 


### PR DESCRIPTION
## Description of the change

This adds a trailing slash to all http redirects which removes an unnecessary additional redirect that was causing us SEO issues. Screenshots show the fix in redirect inspector.


![image](https://user-images.githubusercontent.com/1475986/118022935-ca03e180-b311-11eb-878c-e95dbdd6f371.png)


![image](https://user-images.githubusercontent.com/1475986/118022799-9d4fca00-b311-11eb-8879-088236f7685d.png)


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
