### PR TITLE
Added basic rendering of code-snippet contentful blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ yarn-error.log*
 **/public/workbox-*.js
 **/public/sw.js
 **/public/service-worker.js
+
+# Local Netlify folder
+.netlify

--- a/src/components/pages/blog/Single/Content.tsx
+++ b/src/components/pages/blog/Single/Content.tsx
@@ -41,7 +41,7 @@ function getParagraphString({content}: {content:any[]}) {
     return allText;
 }
 
-const Content = ({content, images}: {content: any[], images: any}) => {
+const Content = ({content, images, snippets}: {content: any[], images: any, snippets: any}) => {
     return (
         <Box mt={"52px"}>
             {
@@ -70,6 +70,13 @@ const Content = ({content, images}: {content: any[], images: any}) => {
                         const allContent = getParagraphString({content: row.content});
                         return (
                             <Text mt={6} dangerouslySetInnerHTML={{__html: allContent}} />
+                        )
+                    }
+
+                    // This isn't currently checking to make sure it's a code snippet block
+                    if(row.nodeType === "embedded-entry-block") {
+                        return (
+                            <code style={{display: "block", whiteSpace: "pre-wrap", color: "#FCEDE3", backgroundColor: "#2C1338", padding: "10px", margin: "10px 0px", borderRadius: "10px"}}>{snippets[row.data.target.sys.id].code}</code>
                         )
                     }
                 })

--- a/src/components/pages/blog/Single/Content.tsx
+++ b/src/components/pages/blog/Single/Content.tsx
@@ -73,11 +73,13 @@ const Content = ({content, images, snippets}: {content: any[], images: any, snip
                         )
                     }
 
-                    // This isn't currently checking to make sure it's a code snippet block
                     if(row.nodeType === "embedded-entry-block") {
-                        return (
-                            <code style={{display: "block", whiteSpace: "pre-wrap", color: "#FCEDE3", backgroundColor: "#2C1338", padding: "10px", margin: "10px 0px", borderRadius: "10px"}}>{snippets[row.data.target.sys.id].code}</code>
-                        )
+                        // Ignoring if not a snippet
+                        if (row.data.target.sys.id in snippets) {
+                            return (
+                                <code style={{display: "block", whiteSpace: "pre-wrap", color: "#FCEDE3", backgroundColor: "#2C1338", padding: "10px", margin: "10px 0px", borderRadius: "10px"}}>{snippets[row.data.target.sys.id].code}</code>
+                            )
+                        }
                     }
                 })
             }

--- a/src/components/pages/blog/Single/index.tsx
+++ b/src/components/pages/blog/Single/index.tsx
@@ -42,18 +42,19 @@ interface SingleBlogProps {
     publishDate: Date;
     content: ContentProps;
     images: object;
+    snippets: object;
     slug: string
     moreFromTagName: string;
     moreBlogs: any[]
 }
 
-const SingleBlogContent = ({headerImage, title, tagsCollection, publishDate, authorsCollection, content, images, moreFromTagName, moreBlogs}: SingleBlogProps) => (
+const SingleBlogContent = ({headerImage, title, tagsCollection, publishDate, authorsCollection, content, images, snippets, moreFromTagName, moreBlogs}: SingleBlogProps) => (
     <Box color="secondary.dark" maxW={980} mx="auto" pt={{base: "132px", lg: "92px"}} p="0 20px">
         <ViewAllPosts />
         <Image src={headerImage.url} borderRadius="16px" mt={"62px"}/>
         <Headline title={title} tags={tagsCollection} />
         <Author name={authorsCollection.items[0].name} avatar={authorsCollection.items[0].avatar.url} publishDate={publishDate} />
-        <Content content={content.json.content} images={images} />
+        <Content content={content.json.content} images={images} snippets={snippets}/>
         <MoreFrom moreFromTagName={moreFromTagName} moreBlogs={moreBlogs} />
     </Box>          
 );

--- a/src/scripts/GetBlogPost.tsx
+++ b/src/scripts/GetBlogPost.tsx
@@ -66,8 +66,18 @@ async function getBlogPostDetails({blogPostId}: {blogPostId: string}) {
                         links {
                             assets {
                                 block {
-                                sys { id  }
-                                url
+                                    sys { id  }
+                                    url
+                                }
+                            }
+                            entries {
+                                block {
+                                    sys { id }
+                                    ... on CodeSnippet {
+                                        title
+                                        language
+                                        code
+                                    }
                                 }
                             }
                         }
@@ -86,6 +96,20 @@ async function getBlogPostDetails({blogPostId}: {blogPostId: string}) {
         blogImages[thisImage.sys.id] = thisImage.url;   
     }
     blogPostDetails.images = blogImages;
+
+    const blogSnippets:any = {};
+    const codeSnippetsArrRaw = data.data.post.content.links.entries.block;
+    for (let index = 0; index < codeSnippetsArrRaw.length; index++) {
+        const thisSnippet = codeSnippetsArrRaw[index];
+        blogSnippets[thisSnippet.sys.id] = {
+            title: thisSnippet.title,
+            language: thisSnippet.language,
+            code: thisSnippet.code
+        };   
+    }
+    console.log(blogSnippets);
+    blogPostDetails.snippets = blogSnippets;
+
     return blogPostDetails;
 }
 


### PR DESCRIPTION
## Description of the change

Basic rendering using a `<code>` tag. Need to add checking for other type of block embeds. Will probably need to update the contentful graphql query so we can add that check to the if.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
