### PR TITLE
Add Vercel Insights CSP

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -9,7 +9,7 @@ module.exports = [
             {
                 key: 'Content-Security-Policy',
                 value: "base-uri 'self'; \
-                connect-src 'self' api.segment.io api-iam.intercom.io forms.hubspot.com www.google-analytics.com heapanalytics.com wss://nexus-websocket-a.intercom.io api.hubapi.com www.google.com stats.g.doubleclick.net api.hsforms.com; \
+                connect-src 'self' api.segment.io api-iam.intercom.io forms.hubspot.com www.google-analytics.com heapanalytics.com wss://nexus-websocket-a.intercom.io api.hubapi.com www.google.com stats.g.doubleclick.net api.hsforms.com vitals.vercel-insights.com; \
                 default-src 'self' api-iam.intercom.io api.segment.io cdn.heapanalytics.com cdn.segment.io fonts.googleapis.com fonts.gstatic.com forms.hubspot.com heapanalytics.com  js-na1.hs-scripts.com js.hs-analytics.net js.hs-banner.com js.hscollectedforms.net js.intercomcdn.com self track.hubspot.com widget.intercom.io www.google-analytics.com www.googletagmanager.com null images.ctfassets.net wss://nexus-websocket-a.intercom.io api.hubapi.com connect.facebook.net js.hsadspixel.net px.ads.linkedin.com snap.licdn.com www.facebook.com www.google.com www.google.dk downloads.intercomcdn.com messenger-apps.intercom.io static.intercomassets.com www.google.co.in www.google.co.nz www.google.ca www.google.com.br www.google.com.do www.google.es www.youtube.com wss www.google.fr www.google.hu www.google.lu www.linkedin.com; \
                 font-src 'self' data: fonts.gstatic.com js.intercomcdn.com www.slant.co storage.googleapis.com; \
                 form-action calendly.com; \

--- a/headers.js
+++ b/headers.js
@@ -19,7 +19,7 @@ module.exports = [
                 manifest-src 'self'; \
                 media-src js.intercomcdn.com; \
                 object-src 'none'; \
-                script-src 'self' cdn.segment.io js.intercomcdn.com widget.intercom.io cdn.heapanalytics.com js-na1.hs-scripts.com js.hs-analytics.net js.hs-banner.com js.hscollectedforms.net www.google-analytics.com www.googletagmanager.com js.hsadspixel.net snap.licdn.com; \
+                script-src 'self' cdn.segment.io js.intercomcdn.com widget.intercom.io cdn.heapanalytics.com js-na1.hs-scripts.com js.hs-analytics.net js.hs-banner.com js.hscollectedforms.net www.google-analytics.com www.googletagmanager.com js.hsadspixel.net snap.licdn.com vitals.vercel-insights.com; \
                 script-src-elem 'self' 'unsafe-inline' widget.intercom.io www.google-analytics.com www.googletagmanager.com cdn.heapanalytics.com cdn.segment.com js-na1.hs-scripts.com js.hs-analytics.net js.hs-banner.com js.hscollectedforms.net js.intercomcdn.com js.hsadspixel.net snap.licdn.com www.google.com analytics.twitter.com static.ads-twitter.com www.googleadservices.com googleads.g.doubleclick.net stats.g.doubleclick.net js.hsleadflows.net; \
                 style-src 'self' 'unsafe-inline' fonts.googleapis.com; \
                 style-src-elem 'self' 'unsafe-inline' fonts.googleapis.com; \

--- a/headers.js
+++ b/headers.js
@@ -20,7 +20,7 @@ module.exports = [
                 media-src js.intercomcdn.com; \
                 object-src 'none'; \
                 script-src 'self' cdn.segment.io js.intercomcdn.com widget.intercom.io cdn.heapanalytics.com js-na1.hs-scripts.com js.hs-analytics.net js.hs-banner.com js.hscollectedforms.net www.google-analytics.com www.googletagmanager.com js.hsadspixel.net snap.licdn.com vitals.vercel-insights.com; \
-                script-src-elem 'self' 'unsafe-inline' widget.intercom.io www.google-analytics.com www.googletagmanager.com cdn.heapanalytics.com cdn.segment.com js-na1.hs-scripts.com js.hs-analytics.net js.hs-banner.com js.hscollectedforms.net js.intercomcdn.com js.hsadspixel.net snap.licdn.com www.google.com analytics.twitter.com static.ads-twitter.com www.googleadservices.com googleads.g.doubleclick.net stats.g.doubleclick.net js.hsleadflows.net; \
+                script-src-elem 'self' 'unsafe-inline' widget.intercom.io www.google-analytics.com www.googletagmanager.com cdn.heapanalytics.com cdn.segment.com js-na1.hs-scripts.com js.hs-analytics.net js.hs-banner.com js.hscollectedforms.net js.intercomcdn.com js.hsadspixel.net snap.licdn.com www.google.com analytics.twitter.com static.ads-twitter.com www.googleadservices.com googleads.g.doubleclick.net stats.g.doubleclick.net js.hsleadflows.net vitals.vercel-insights.com; \
                 style-src 'self' 'unsafe-inline' fonts.googleapis.com; \
                 style-src-elem 'self' 'unsafe-inline' fonts.googleapis.com; \
                 worker-src 'self';"


### PR DESCRIPTION
Vercel Analytics (VA) is a tool to help us monitor and improve website performance.

Adding vitals.vercel-insights.com to CSP to enable VA. 

