### PR TITLE
Fix markdown images to support both cdn domains

### DIFF
--- a/src/components/pages/blog/Single/MarkdownContent.tsx
+++ b/src/components/pages/blog/Single/MarkdownContent.tsx
@@ -38,10 +38,10 @@ const YouTubeEmbed = ({ embedUrl }: { embedUrl: string }) => {
 };
 
 const MarkdownContent = ({
-  imageDimensions,
+  assets,
   content,
 }: {
-  imageDimensions: Record<string, { width: number; height: number }>;
+  assets: Record<string, { url: string; width: number; height: number }>;
   content: string;
 }) => {
   return (
@@ -115,7 +115,7 @@ const MarkdownContent = ({
             },
             a: {
               component: (props) => {
-                if (props.href.includes("youtube.com")) {
+                if (props.href.includes("youtube.com/embed")) {
                   return <YouTubeEmbed embedUrl={props.href} />;
                 }
 
@@ -155,19 +155,19 @@ const MarkdownContent = ({
             },
             img: {
               component: (props) => {
-                const dimensions = imageDimensions[props.src];
+                const assetId = props.src.split("/")[4];
+                const asset = assets[assetId || ""];
 
-                if (!dimensions) return null;
+                if (!asset) return null;
 
                 return (
                   <Box my={10}>
                     <Image
-                      src={`https:${props.src}`}
+                      src={`https:${asset.url}`}
                       alt={props.alt}
                       title={props.title}
-                      layout="responsive"
-                      width={dimensions.width}
-                      height={dimensions.height}
+                      width={asset.width}
+                      height={asset.height}
                       quality={100}
                     />
                   </Box>

--- a/src/components/pages/blog/Single/index.tsx
+++ b/src/components/pages/blog/Single/index.tsx
@@ -51,7 +51,7 @@ interface SingleBlogProps {
   publishDate: Date;
   content: ContentProps;
   contentMd?: string;
-  imageDimensions: Record<string, { width: number; height: number }>;
+  assets: Record<string, { url: string; width: number; height: number }>;
   images: object;
   snippets: object;
   slug: string;
@@ -68,7 +68,7 @@ const SingleBlogContent = ({
   authorsCollection,
   content,
   contentMd,
-  imageDimensions,
+  assets,
   images,
   snippets,
   moreFromTagName,
@@ -121,10 +121,7 @@ const SingleBlogContent = ({
         <SocialShare slug={slug} title={title} />
       </Flex>
       {contentMd ? (
-        <MarkdownContent
-          imageDimensions={imageDimensions}
-          content={contentMd}
-        />
+        <MarkdownContent assets={assets} content={contentMd} />
       ) : (
         <RichContent
           content={content.json.content}


### PR DESCRIPTION
The markdown editor on Contentful inserts images with `images.contentful.com` as the CDN domain when uploading new images, otherwise the domain for the asset urls is always `images.ctfassets.net`.
